### PR TITLE
Add walletd to supported packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The following packages are supported
 
 - [renterd](https://github.com/SiaFoundation/renterd)
 - [hostd](https://github.com/SiaFoundation/hostd)
+- [walletd](https://github.com/SiaFoundation/walletd)
 
 ## Adding the Repository
 


### PR DESCRIPTION
`walletd` packages have been published to this repo for a long time but the README never listed it. Adds it to the supported packages list.
