### PR TITLE
Add `s3d` to supported packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The following packages are supported
 
 - [renterd](https://github.com/SiaFoundation/renterd)
 - [hostd](https://github.com/SiaFoundation/hostd)
+- [s3d](https://github.com/SiaFoundation/s3d)
 
 ## Adding the Repository
 
@@ -72,3 +73,18 @@ $ sudo systemctl enable --now hostd
 
 If you want to install a different package just replace `hostd` in the
 commands with a different package name.
+
+### s3d
+
+s3d needs to be registered with the indexer before the daemon can start.
+After installing and configuring it, run the following commands once before
+enabling the service:
+
+```bash
+# register this s3d instance with the indexer
+$ s3d login
+
+# create a user and an S3 access key
+$ s3d users create <username>
+$ s3d keys create <username>
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The following packages are supported
 
 - [renterd](https://github.com/SiaFoundation/renterd)
 - [hostd](https://github.com/SiaFoundation/hostd)
-- [s3d](https://github.com/SiaFoundation/s3d)
+- [sia-s3d](https://github.com/SiaFoundation/s3d)
 - [walletd](https://github.com/SiaFoundation/walletd)
 
 ## Adding the Repository
@@ -76,6 +76,9 @@ If you want to install a different package just replace `hostd` in the
 commands with a different package name.
 
 ### s3d
+
+Install this package with `sudo apt install sia-s3d`. The command and systemd
+service are named `s3d`.
 
 s3d needs to be registered with the indexer before the daemon can start.
 `s3d login` walks you through the initial configuration and registers this

--- a/README.md
+++ b/README.md
@@ -77,14 +77,15 @@ commands with a different package name.
 ### s3d
 
 s3d needs to be registered with the indexer before the daemon can start.
-After installing and configuring it, run the following commands once before
-enabling the service:
+`s3d login` walks you through the initial configuration and registers this
+instance with the indexer. Run the following commands once before enabling the
+service:
 
 ```bash
-# register this s3d instance with the indexer
-$ s3d login
+# configure s3d and register it with the indexer
+$ sudo s3d login
 
 # create a user and an S3 access key
-$ s3d users create <username>
-$ s3d keys create <username>
+$ sudo s3d users create <username>
+$ sudo s3d keys create <username>
 ```

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ commands with a different package name.
 
 s3d needs to be registered with the indexer before the daemon can start.
 `s3d login` walks you through the initial configuration and registers this
-instance with the indexer. Run the following commands once before enabling the
-service:
+instance with the indexer. Run the following commands once to register this
+instance and start the service:
 
 ```bash
 # configure s3d and register it with the indexer
@@ -89,4 +89,7 @@ $ sudo s3d login
 # create a user and an S3 access key
 $ sudo s3d users create <username>
 $ sudo s3d keys create <username>
+
+# enable s3d systemd service
+$ sudo systemctl enable --now s3d
 ```


### PR DESCRIPTION
Adds s3d to the supported packages list along with a short setup section: s3d requires `s3d login` plus user and access key creation before the service is useful. An enabled but unconfigured s3d restarts every 15 seconds until that is done, same as the other daemons. We should manually run the `Build .deb Packages` workflow before merging this.
